### PR TITLE
Add missing `setuptools_scm[toml]` dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -33,6 +33,7 @@ requirements:
     - numcodecs >=0.9.0
     - rechunker >=0.4.2
     - setuptools
+    - setuptools_scm[toml] >=6.0
     - xarray >=0.18.0
     - zarr >=2.6.0
     - netcdf4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   host:
     - python
     - pip
+    - setuptools_scm[toml] >=6.0
   run:
     - python >=3.8
     - dask
@@ -33,7 +34,6 @@ requirements:
     - numcodecs >=0.9.0
     - rechunker >=0.4.2
     - setuptools
-    - setuptools_scm[toml] >=6.0
     - xarray >=0.18.0
     - zarr >=2.6.0
     - netcdf4


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

According to https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=505339&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d&l=152, it looks like this dependency was missing, and therefore breaking our latest build.

<!--
Please add any other relevant info below:
-->
